### PR TITLE
upgrade @rollup/plugin-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4500,13 +4500,13 @@
       }
     },
     "@rollup/plugin-typescript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-2.1.0.tgz",
-      "integrity": "sha512-7lXKGY06aofrceVez/YnN2axttFdHSqlUBpCJ6ebzDfxwLDKMgSV5lD4ykBcdgE7aK3egxuLkD/HKyRB5L8Log==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-3.0.0.tgz",
+      "integrity": "sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.0",
-        "resolve": "^1.13.1"
+        "@rollup/pluginutils": "^3.0.1",
+        "resolve": "^1.14.1"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-typescript": "^7.8.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.0",
-    "@rollup/plugin-typescript": "^2.1.0",
+    "@rollup/plugin-typescript": "^3.0.0",
     "@types/astring": "^1.3.0",
     "@types/estree": "0.0.42",
     "@types/jest": "^25.1.1",

--- a/src/test/tools/rollup.test.ts
+++ b/src/test/tools/rollup.test.ts
@@ -14,7 +14,7 @@ import commonjs from "@rollup/plugin-commonjs";
 
 describe("Rollup", () => {
 
-    jest.setTimeout(10000);
+    jest.setTimeout(30000);
 
     async function test(sandbox: object, options: InputOptions): Promise<void> {
         const inputFile = tempy.file({ extension: "jsx" });


### PR DESCRIPTION
The TS plugin now uses full type-checking, which means the tests takes longer.

Supersedes #39 